### PR TITLE
Fix HMAC message concatenation separator for clarity

### DIFF
--- a/src/main/java/cc/baka9/catseedlogin/common/util/CommunicationAuth.java
+++ b/src/main/java/cc/baka9/catseedlogin/common/util/CommunicationAuth.java
@@ -33,7 +33,7 @@ public class CommunicationAuth {
     if (key == null || key.isEmpty()) {
       throw new IllegalArgumentException("HMAC key must not be null or empty");
     }
-    String message = String.join("", data);
+    String message = String.join(":", data);
     Mac mac = MAC.get();
     try {
       mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), HMAC_SHA256));


### PR DESCRIPTION
将原本无分隔的字符串拼接改为使用冒号分隔，避免不同数据段拼接后产生歧义